### PR TITLE
ap - Set up Edit Page for HelpRequest

### DIFF
--- a/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.jsx
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.jsx
@@ -1,11 +1,80 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: helpRequest,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/HelpRequest?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/HelpRequest`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (helpRequest) => ({
+    url: "/api/HelpRequest",
+    method: "PUT",
+    params: {
+      id: helpRequest.id,
+    },
+    data: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(
+      `HelpRequest Updated - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/HelpRequest?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/HelpRequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit HelpRequest</h1>
+        {helpRequest && (
+          <HelpRequestForm
+            initialContents={helpRequest}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestEditPage",
+  component: HelpRequestEditPage,
+};
+
+const Template = () => <HelpRequestEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/HelpRequest", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/HelpRequest", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.jsx
@@ -1,47 +1,246 @@
-import { render, screen } from "@testing-library/react";
-import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
 
-describe("HelpRequestEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    setupUserOnly();
+let axiosMock;
+describe("HelpRequestEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/HelpRequest", { params: { id: 17 } }).timeout();
+    });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <HelpRequestEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText(/Welcome/);
+      await screen.findByText("Edit HelpRequest");
+      expect(
+        screen.queryByTestId("HelpRequestForm-requesterEmail"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/HelpRequest", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        requesterEmail: "alicegaucho@ucsb.edu",
+        teamId: "01",
+        tableOrBreakoutRoom: "01",
+        requestTime: "2025-10-31T12:20",
+        explanation: "Need help with git:sync on dokku.",
+        solved: false,
+      });
+      axiosMock.onPut("/api/HelpRequest").reply(200, {
+        id: "17",
+        requesterEmail: "chrisgaucho@ucsb.edu",
+        teamId: "05",
+        tableOrBreakoutRoom: "05",
+        requestTime: "2025-11-03T12:10",
+        explanation: "No help needed.",
+        solved: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText(/Welcome/);
+      await screen.findByTestId("HelpRequestForm-requesterEmail");
+      expect(
+        screen.getByTestId("HelpRequestForm-requesterEmail"),
+      ).toBeInTheDocument();
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("HelpRequestForm-requesterEmail");
+
+      const idField = screen.getByTestId("HelpRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "HelpRequestForm-requesterEmail",
+      );
+      const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+      const tableOrBreakoutRoomField = screen.getByTestId(
+        "HelpRequestForm-tableOrBreakoutRoom",
+      );
+      const requestTimeField = screen.getByTestId(
+        "HelpRequestForm-requestTime",
+      );
+      const explanationField = screen.getByTestId(
+        "HelpRequestForm-explanation",
+      );
+      const solvedField = screen.getByTestId("HelpRequestForm-solved");
+      const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toHaveValue("alicegaucho@ucsb.edu");
+      expect(teamIdField).toHaveValue("01");
+      expect(tableOrBreakoutRoomField).toHaveValue("01");
+      expect(requestTimeField).toHaveValue("2025-10-31T12:20");
+      expect(explanationField).toHaveValue("Need help with git:sync on dokku.");
+      expect(solvedField).not.toBeChecked();
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("HelpRequestForm-requesterEmail");
+
+      const idField = screen.getByTestId("HelpRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "HelpRequestForm-requesterEmail",
+      );
+      const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+      const tableOrBreakoutRoomField = screen.getByTestId(
+        "HelpRequestForm-tableOrBreakoutRoom",
+      );
+      const requestTimeField = screen.getByTestId(
+        "HelpRequestForm-requestTime",
+      );
+      const explanationField = screen.getByTestId(
+        "HelpRequestForm-explanation",
+      );
+      const solvedField = screen.getByTestId("HelpRequestForm-solved");
+      const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toHaveValue("alicegaucho@ucsb.edu");
+      expect(teamIdField).toHaveValue("01");
+      expect(tableOrBreakoutRoomField).toHaveValue("01");
+      expect(requestTimeField).toHaveValue("2025-10-31T12:20");
+      expect(explanationField).toHaveValue("Need help with git:sync on dokku.");
+      expect(solvedField).not.toBeChecked();
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "chrisgaucho@ucsb.edu" },
+      });
+      fireEvent.change(teamIdField, { target: { value: "05" } });
+      fireEvent.change(tableOrBreakoutRoomField, { target: { value: "05" } });
+      fireEvent.change(requestTimeField, {
+        target: { value: "2025-11-03T12:10" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "No help needed." },
+      });
+      fireEvent.click(solvedField);
+
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "HelpRequest Updated - id: 17 requesterEmail: chrisgaucho@ucsb.edu",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/HelpRequest" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          requesterEmail: "chrisgaucho@ucsb.edu",
+          teamId: "05",
+          tableOrBreakoutRoom: "05",
+          requestTime: "2025-11-03T12:10",
+          explanation: "No help needed.",
+          solved: true,
+        }),
+      ); // posted object
+    });
   });
 });


### PR DESCRIPTION
Closes #51 

## Dependencies 
To be merged after PR #90

## Description 
- Changed placeholder `Edit` page to a fully implemented page with backend communication. 
- Created storybook entry for verification purposes.
- Added comprehensive tests.

## Testing
### stryker
<img width="2377" height="939" alt="image" src="https://github.com/user-attachments/assets/71c13fcd-d656-4327-a995-76c91efc6870" />

## Expected Output
### `Edit` page of `HelpRequest` created at the following link: https://team02-dev-ajp1012.dokku-04.cs.ucsb.edu/
<img width="1861" height="412" alt="image" src="https://github.com/user-attachments/assets/17292e5e-6c17-41eb-a8ff-1d46ca981e34" />

### After editing:
<img width="2044" height="426" alt="image" src="https://github.com/user-attachments/assets/89d3c62e-ed19-4f4f-977e-d5b1f3b4ca9b" />

Storybook link: https://6902872edc991b2bf7185803-urfufcsunf.chromatic.com/?path=/story/pages-helprequest-helprequesteditpage--default
